### PR TITLE
Fix Issue on Google Cloud

### DIFF
--- a/WDL/kallisto-bustools_count.wdl
+++ b/WDL/kallisto-bustools_count.wdl
@@ -126,12 +126,11 @@ task count {
 		set -e
 		export TMPDIR=/tmp
 
-		mkdir ~/count~{'_'+sample_name}
 		kb count --verbose \
 			-i ~{index} \
 			-g ~{T2G_mapping} \
 			-x ~{technology} \
-			-o ~/count~{'_'+sample_name} \
+			-o result \
 			~{"-w "+barcodes_whitelist} \
 			~{true="--lamanno" false='' use_lamanno} \
 			~{"-c1 "+cDNA_transcripts_to_capture} \
@@ -146,14 +145,14 @@ task count {
 			~{R2_fastq}
 
 		if [ "~{delete_bus_files}" = "true" ]; then
-			rm -vf ~/count~{'_'+sample_name}/*.bus
+			rm -vf result/*.bus
 		fi
-		gsutil mv ~/count~{'_'+sample_name} ~{bucket_slash}~{output_path_slash}
+		gsutil -m rsync -r result ~{bucket_slash}~{output_path_slash}~{sample_name}
 	}
 	output {
-		String count_output_path = "~{bucket_slash}~{output_path_slash}count~{'_'+sample_name}/"
-		String counts_unfiltered_matrix = "~{bucket_slash}~{output_path_slash}count~{'_'+sample_name}/counts_unfiltered/cells_x_genes.mtx"
-		String counts_filtered_matrix = "~{bucket_slash}~{output_path_slash}count~{'_'+sample_name}/counts_filtered/cells_x_genes.mtx"
+		String count_output_path = "~{bucket_slash}~{output_path_slash}~{sample_name}"
+		String counts_unfiltered_matrix = "~{bucket_slash}~{output_path_slash}~{sample_name}/counts_unfiltered/cells_x_genes.mtx"
+		String counts_filtered_matrix = "~{bucket_slash}~{output_path_slash}~{sample_name}/counts_filtered/cells_x_genes.mtx"
 	}
 	runtime {
 		docker: "~{docker}"


### PR DESCRIPTION
## Issue
When running with a smaller ``boot_disk_size_GB`` input (e.g. 12), the job failed on 10X 5k PBMC V3 dataset with the default 300GB SSD local disk and 256GB memory, with the following error message:
```
Task kallisto_bustools_count.count:NA:1 failed. The job was stopped before the command finished. PAPI error code 2. Execution failed: action 15: preparing standard output: creating logs root: mkdir /var/lib/pipelines/google/logs/action/15: no space left on device
```
However, this is actually not due to lack of disk space, as Bustools was able to finish on Google Cloud VM instance machine with the same resources.

## Solution
In ``command`` section, change the temporary output folder from ``/root`` (i.e. ``~``) to ``/``.

## Additional Modification
* No need to explicitly create this temporary output folder before running ``kb count``.
* Use ``-m`` when copying results to target GS bucket.
* The target output folder uses ``sample_name`` as its name.
* No need to delete results in temporary output folder, as the space will be released when the docker container terminates.